### PR TITLE
Upgrade to JGit 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,7 @@
   	<dependency>
   		<groupId>org.eclipse.jgit</groupId>
   		<artifactId>org.eclipse.jgit</artifactId>
-  		<version>2.2.0.201212191850-r</version>
-  		<type>maven-plugin</type>
+  		<version>3.0.0.201306101825-r</version>
   	</dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
This allows to get rid of the workaround for checking out a branch after
clone, see the following bug which was fixed in 3.0.0:

https://bugs.eclipse.org/bugs/show_bug.cgi?id=390994

WindowCache became internal, but it's no longer necessary with the
different approach for checking out a commit, so remove the code.
